### PR TITLE
feat: Add SignInScreen features and navigation, update states and rep…

### DIFF
--- a/app/src/main/java/com/example/droidchat/commom/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/droidchat/commom/data/repository/AuthRepository.kt
@@ -9,7 +9,7 @@ interface AuthRepository {
 
     suspend fun signUp(createAccount: CreateAccount): Result<Unit>
 
-    suspend fun signIn(loginAccount: LoginAccount)
+    suspend fun signIn(loginAccount: LoginAccount): Result<Unit>
 
     suspend fun profilePicture(filePath: String): Result<ImageDomain>
 

--- a/app/src/main/java/com/example/droidchat/commom/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/droidchat/commom/data/repository/AuthRepositoryImpl.kt
@@ -27,9 +27,13 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun signIn(loginAccount: LoginAccount) {
-        val response = loginAccount.toSignInRequest()
-        networkDataSource.signIn(response)
+    override suspend fun signIn(loginAccount: LoginAccount): Result<Unit> {
+        return withContext(ioDispacher) {
+            runCatching {
+                val response = loginAccount.toSignInRequest()
+                networkDataSource.signIn(response)
+            }.map { Unit }
+        }
     }
 
     override suspend fun profilePicture(filePath: String): Result<ImageDomain> {

--- a/app/src/main/java/com/example/droidchat/features/HomeScreen.kt
+++ b/app/src/main/java/com/example/droidchat/features/HomeScreen.kt
@@ -1,0 +1,34 @@
+package com.example.droidchat.features
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun HomeScreen() {
+    HomeContent()
+}
+
+@Composable
+private fun HomeContent() {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize()
+    ) {
+
+    }
+    Text("Home")
+}
+
+
+@Preview
+@Composable
+private fun HomePreview() {
+    HomeScreen()
+}

--- a/app/src/main/java/com/example/droidchat/features/signin/presentation/state/SignInState.kt
+++ b/app/src/main/java/com/example/droidchat/features/signin/presentation/state/SignInState.kt
@@ -6,5 +6,7 @@ data class SignInState(
     var password: String = "",
     val passwordErrorMessage: String? = null,
     var isLoading: Boolean = false,
-    var hasError: Boolean = false
+    var hasError: Boolean = false,
+    var isSignedIn: Boolean = false,
+    val apiErrorMessageResId: String? = null,
 )

--- a/app/src/main/java/com/example/droidchat/features/signin/presentation/ui/SignInScreen.kt
+++ b/app/src/main/java/com/example/droidchat/features/signin/presentation/ui/SignInScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -23,7 +24,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.droidchat.R
+import com.example.droidchat.commom.components.AlertDialogCustom
 import com.example.droidchat.commom.components.CommomButton
 import com.example.droidchat.commom.components.PrimaryTextFieldCustom
 import com.example.droidchat.commom.theme.BackgroundGradient
@@ -35,15 +38,30 @@ import com.example.droidchat.features.signin.presentation.viewmodel.SignInViewMo
 @Composable
 fun SignInScreen(
     navigateToSignUp: () -> Unit,
-    hiltViewModel: SignInViewModel = hiltViewModel()
+    navigateToHome: () -> Unit,
+    viewmodel: SignInViewModel = hiltViewModel()
 ) {
-    val uiState by hiltViewModel.uiState.collectAsState()
+    val uiState by viewmodel.uiState.collectAsState()
 
+    if (uiState.isSignedIn){
+        AlertDialogCustom(
+            onDismissRequest = navigateToHome,
+            onConfirmButton = navigateToHome,
+            text = "Logado com sucesso",
+        )
+    }
 
+    uiState.apiErrorMessageResId?.let {
+        AlertDialogCustom(
+            onDismissRequest = viewmodel::onDismissDialog,
+            onConfirmButton = viewmodel::onDismissDialog,
+            text = it,
+        )
+    }
 
     SignInContent(
         uiState = uiState,
-        onActions = hiltViewModel::onActions,
+        onActions = viewmodel::onActions,
         navigateToSignUp = navigateToSignUp
     )
 
@@ -118,5 +136,8 @@ fun SignInContent(
 @Preview
 @Composable
 private fun SignInScreenPreview() {
-    SignInScreen({})
+    SignInScreen(
+        navigateToSignUp = {},
+        navigateToHome = {}
+    )
 }

--- a/app/src/main/java/com/example/droidchat/features/signup/presentation/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/droidchat/features/signup/presentation/viewmodel/SignUpViewModel.kt
@@ -159,7 +159,6 @@ class SignUpViewModel @Inject constructor(
                 val compressedImage = imageCompressor.compressAndResizeImage(uri)
                 _uiState.update { it.copy(profilePictureUri = compressedImage.toUri()) }
             } catch (e: Exception) {
-
             } finally {
                 _uiState.update { it.copy(isCompressingImage = false) }
             }

--- a/app/src/main/java/com/example/droidchat/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/droidchat/navigation/MainNavHost.kt
@@ -7,15 +7,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.droidchat.commom.extension.slideInTo
 import com.example.droidchat.commom.extension.slideOutTo
+import com.example.droidchat.features.HomeScreen
 import com.example.droidchat.features.SignInGoogleAndFacebookScreen
 import com.example.droidchat.features.signin.presentation.ui.SignInScreen
 import com.example.droidchat.features.signup.presentation.ui.SignUpScreen
 import com.example.droidchat.features.splash.presentation.ui.SplashScreen
-import com.example.droidchat.navigation.MainRoutes.LoginRoute
-import com.example.droidchat.navigation.MainRoutes.SignInGoogleAndFacebookRoute
-import com.example.droidchat.navigation.MainRoutes.SignInRoute
-import com.example.droidchat.navigation.MainRoutes.SignUpRoute
-import com.example.droidchat.navigation.MainRoutes.SplashRoute
+import com.example.droidchat.navigation.MainRoutes.*
 
 @Composable
 fun MainNavHost() {
@@ -58,6 +55,9 @@ fun MainNavHost() {
             SignInScreen(
                 navigateToSignUp = {
                     navController.navigate(SignUpRoute)
+                },
+                navigateToHome = {
+                    navController.navigate(HomeRoute)
                 }
             )
         }
@@ -68,6 +68,8 @@ fun MainNavHost() {
                 }
             )
         }
-        composable<LoginRoute> {}
+        composable<HomeRoute> {
+            HomeScreen()
+        }
     }
 }

--- a/app/src/main/java/com/example/droidchat/navigation/MainRoutes.kt
+++ b/app/src/main/java/com/example/droidchat/navigation/MainRoutes.kt
@@ -7,11 +7,11 @@ sealed class MainRoutes {
     @Serializable
     data object SplashRoute : MainRoutes()
     @Serializable
-    data object LoginRoute : MainRoutes()
-    @Serializable
-    data object SignInRoute : MainRoutes()
-    @Serializable
     data object SignInGoogleAndFacebookRoute: MainRoutes()
     @Serializable
     data object SignUpRoute : MainRoutes()
+    @Serializable
+    data object SignInRoute : MainRoutes()
+    @Serializable
+    data object HomeRoute : MainRoutes()
 }


### PR DESCRIPTION
…ository

This commit introduces several enhancements to the sign-in process and includes navigation updates:

- Adds `isSignedIn` and `apiErrorMessageResId` to `SignInState` for better state management.
- Updates `SignInViewModel` to handle sign-in logic, including success and error scenarios with corresponding UI updates.
- Refactors `AuthRepositoryImpl` to return a `Result<Unit>` for sign-in, improving error handling.
- Introduces `HomeScreen` as a placeholder for the main application interface.
- Modifies `SignInScreen` to display error dialogs based on `apiErrorMessageResId` and navigate to `HomeScreen` upon successful sign-in.
- Updates `MainRoutes` to include a `HomeRoute` for navigation to the home screen.
- Adjusts `MainNavHost` to include the `HomeRoute` and sets up navigation from `SignInScreen` to `HomeScreen`.
- Modifies `AuthRepository` to reflect the updated sign-in method signature.